### PR TITLE
fix: Fix invalid filegroup in nextjs config

### DIFF
--- a/javascript/next/tasks.yml
+++ b/javascript/next/tasks.yml
@@ -8,8 +8,7 @@ fileGroups:
     - 'src/**/*'
     - 'next-env.d.ts'
     - 'next.config.*'
-  sources:
-    - []
+  sources: []
   tests:
     - 'tests/**/*'
 


### PR DESCRIPTION
Ran into this error while trying to use the Nextjs config:

```
Error: config::parse::failed

  × Failed to parse https://raw.githubusercontent.com/moonrepo/moon-configs/master/javascript/next/tasks.yml.
  ╰─▶   × fileGroups.sources[0]: invalid type: sequence, expected a string
```