### PR TITLE
update: Remix v2

### DIFF
--- a/javascript/remix/tasks.yml
+++ b/javascript/remix/tasks.yml
@@ -18,7 +18,7 @@ tasks:
 
   # Build the application
   build:
-    command: 'remix build'
+    command: 'remix vite:build'
     inputs:
       - '@group(remix)'
       - '@group(sources)'
@@ -28,12 +28,12 @@ tasks:
 
   # Run the development server
   dev:
-    command: 'remix dev'
+    command: 'remix vite:dev'
     local: true
 
   # Serve the built application
   start:
-    command: 'remix-serve ./build'
+    command: 'remix-serve ./build/server/index.js'
     deps:
       - 'build'
     local: true


### PR DESCRIPTION
Remix v2 uses Vite by default now so the commands to build and run are slightly different. The commands are just copied from the `package.json` in a newly generated Remix project.

```json
  "scripts": {
    "build": "remix vite:build",
    "dev": "remix vite:dev",
    "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
    "start": "remix-serve ./build/server/index.js",
    "typecheck": "tsc"
  },
```