### PR TITLE
Add Task Definitions for Strapi and Medusa

### DIFF
--- a/javascript/medusa/README.md
+++ b/javascript/medusa/README.md
@@ -1,0 +1,21 @@
+# Medusa
+
+## Requirements
+
+- Medusa.js installed in your project.
+
+## Setup
+
+In your moon workspace, create a `.moon/tasks/tag-medusa.yml` file, and paste the following contents:
+
+```yaml
+# .moon/tasks/tag-medusa.yml
+extends: 'https://raw.githubusercontent.com/moonrepo/moon-configs/master/javascript/medusa/tasks.yml'
+```
+
+In your Medusa projects that you'd like to inherit these tasks, add the following tags:
+
+```yaml
+# moon.yml
+tags: ['medusa']
+```

--- a/javascript/medusa/tasks.yml
+++ b/javascript/medusa/tasks.yml
@@ -1,14 +1,10 @@
 $schema: "https://moonrepo.dev/schemas/tasks.json"
 
 fileGroups:
-  next:
-    - "app/**/*"
-    - "pages/**/*"
-    - "public/**/*"
+  sources: 
     - "src/**/*"
-    - "next-env.d.ts"
-    - "medusa-config.*"
-  sources: []
+    - "medusa-config.(js|ts)"
+    - "instrumentation.(js|ts)"
   tests:
     - "integration-tests/**/*"
 
@@ -22,7 +18,6 @@ tasks:
   build:
     command: "medusa build"
     inputs:
-      - "@group(next)"
       - "@group(sources)"
     outputs:
       - ".medusa"

--- a/javascript/medusa/tasks.yml
+++ b/javascript/medusa/tasks.yml
@@ -1,0 +1,77 @@
+$schema: "https://moonrepo.dev/schemas/tasks.json"
+
+fileGroups:
+  next:
+    - "app/**/*"
+    - "pages/**/*"
+    - "public/**/*"
+    - "src/**/*"
+    - "next-env.d.ts"
+    - "medusa-config.*"
+  sources: []
+  tests:
+    - "integration-tests/**/*"
+
+tasks:
+  # Catch-all for any `medusa` command
+  medusa:
+    command: "medusa"
+    local: true
+
+  # Build the application
+  build:
+    command: "medusa build"
+    inputs:
+      - "@group(next)"
+      - "@group(sources)"
+    outputs:
+      - ".medusa"
+
+  # Run the development server
+  dev:
+    command: "medusa develop"
+    local: true
+
+  # Serve the built application
+  start:
+    command: "medusa start"
+    deps:
+      - "build"
+    local: true
+
+  # run medusa scripts
+  exec:
+    command: "medusa exec"
+    local: true
+
+  # Initialize the database
+  db-init:
+    command: "medusa db:setup"
+    local: true
+    options:
+      interactive: true
+
+  # create a database
+  db-create:
+    command: "medusa db:create"
+    local: true
+
+  # migrate the database
+  db-migrate:
+    command: "medusa db:migrate"
+    local: true
+
+  # migrate the database
+  db-generate:
+    command: "medusa db:generate"
+    local: true
+
+  # create a admin user
+  add-admin:
+    command: "medusa user"
+    local: true
+
+  # Disable telemetry
+  disable-telemetry:
+    command: "medusa telemetry --disable"
+    local: true

--- a/javascript/shadcn/README.md
+++ b/javascript/shadcn/README.md
@@ -1,0 +1,21 @@
+# shadcn
+
+## Requirements
+
+- shadcn/ui installed in your project.
+
+## Setup
+
+In your moon workspace, create a `.moon/tasks/tag-shadcn.yml` file, and paste the following contents:
+
+```yaml
+# .moon/tasks/tag-shadcn.yml
+extends: 'https://raw.githubusercontent.com/moonrepo/moon-configs/master/javascript/shadcn/tasks.yml'
+```
+
+In your projects that use shadcn/ui and should inherit these tasks, add the following tags:
+
+```yaml
+# moon.yml
+tags: ['shadcn']
+```

--- a/javascript/shadcn/tasks.yml
+++ b/javascript/shadcn/tasks.yml
@@ -1,0 +1,50 @@
+$schema: "https://moonrepo.dev/schemas/tasks.json"
+
+fileGroups:
+  shadcn:
+    - "src/**/*"
+    - components.json
+  sources: []
+  tests: []
+
+tasks:
+  # Catch-all for any `shadcn` command
+  shadcn:
+    command: "shadcn"
+    local: true
+
+  init:
+    command: "shadcn init"
+    local: true
+
+  add:
+    command: "shadcn add"
+    local: true
+
+  diff:
+    command: "shadcn diff"
+    local: true
+
+  migrate:
+    command: "shadcn migrate"
+    local: true
+
+  info:
+    command: "shadcn info"
+    local: true
+
+  build:
+    command: "shadcn build"
+    local: true
+
+  registry-build:
+    command: "shadcn registry:build"
+    local: true
+
+  registry-mcp:
+    command: "shadcn registry:mcp"
+    local: true
+
+  help:
+    command: "shadcn help"
+    local: true

--- a/javascript/strapi/README.md
+++ b/javascript/strapi/README.md
@@ -1,0 +1,21 @@
+# Strapi
+
+## Requirements
+
+- Strapi >= v5.
+
+## Setup
+
+In your moon workspace, create a `.moon/tasks/tag-strapi.yml` file, and paste the following contents:
+
+```yaml
+# .moon/tasks/tag-strapi.yml
+extends: 'https://raw.githubusercontent.com/moonrepo/moon-configs/master/javascript/strapi/tasks.yml'
+```
+
+In your Strapi projects that you'd like to inherit these tasks, add the following tags:
+
+```yaml
+# moon.yml
+tags: ['strapi']
+```

--- a/javascript/strapi/tasks.yml
+++ b/javascript/strapi/tasks.yml
@@ -1,0 +1,162 @@
+$schema: "https://moonrepo.dev/schemas/tasks.json"
+
+fileGroups:
+  sources:
+    - "config/*"
+    - "database/**/*"
+    - "scripts/**/*"
+    - "src/**/*"
+  assets:
+    - "data/**/*"
+    - "public/**/*"
+    - "favicon.png"
+  tests: []
+
+tasks:
+  # Catch-all for any `strapi` command
+  strapi:
+    command: strapi
+    local: true
+
+  # Start Strapi in watch mode. (Changes in Strapi project files will trigger a server restart)
+  dev:
+    command: strapi develop
+    local: true
+
+  # Start Strapi without watch mode.
+  start:
+    command: strapi start
+    local: true
+    deps:
+      - "build"
+
+  # Build Strapi admin panel.
+  build:
+    command: strapi build
+    inputs:
+      - "@group(sources)"
+    outputs:
+      - "dist"
+
+  # Deploy Strapi project.
+  deploy:
+    command: pnpm strapi deploy
+    local: true
+
+  # Run Strapi console
+  console:
+    command: strapi console
+    local: true
+
+  admin-create:
+    command: strapi admin:create
+    local: true
+
+  admin-reset-password:
+    command: strapi admin:reset-password
+    local: true
+
+  components:
+    command: strapi components:list
+    local: true
+
+  config-dump:
+    command: strapi config:dump
+    local: true
+
+  config-restore:
+    command: strapi config:restore
+    local: true
+
+  content-types:
+    command: strapi content-types:list
+
+  controllers:
+    command: strapi controllers:list
+
+  generate:
+    command: strapi generate
+    local: true
+    options:
+      interactive: true
+
+  hooks:
+    command: strapi hooks:list
+
+  middlewares:
+    command: strapi middlewares:list
+
+  policies:
+    command: strapi policies:list
+
+  report:
+    command: strapi report
+    local: true
+
+  routes:
+    command: strapi routes:list
+
+  services:
+    command: strapi services:list
+
+  telemetry-disable:
+    command: strapi telemetry:disable
+    local: true
+
+  telemetry-enable:
+    command: strapi telemetry:enable
+    local: true
+
+  templates-generate:
+    command: strapi templates:generate
+    local: true
+    options:
+      interactive: true
+
+  ts-generate-types:
+    command: strapi ts:generate-types
+    local: true
+
+  export:
+    command: strapi export
+    outputs:
+      - "exported-data"
+
+  import:
+    command: strapi import
+
+  transfer:
+    command: strapi transfer
+    local: true
+    options:
+      interactive: true
+
+  link:
+    command: strapi link
+    local: true
+    options:
+      interactive: true
+
+  login:
+    command: strapi login
+    local: true
+    options:
+      interactive: true
+
+  logout:
+    command: strapi logout
+    local: true
+
+  cloud:
+    command: strapi cloud
+    local: true
+    options:
+      interactive: true
+
+  projects:
+    command: strapi projects
+    local: true
+
+  help:
+    command: strapi help
+    local: true


### PR DESCRIPTION
## Summary
This PR introduces new task definitions for both [Strapi](https://github.com/strapi/strapi) and [Medusa](https://github.com/medusajs/medusa), enhancing the project’s automation and workflow capabilities.

## Changes
feat: add tasks for medusa
Added task configurations to support [Medusa](https://github.com/medusajs/medusa)-related operations.

feat: add tasks for strapi
Introduced task definitions for [Strapi](https://github.com/strapi/strapi)

## Motivation
These additions aim to improve developer productivity by providing ready-to-use tasks for common operations in both Strapi and Medusa environments.

## Testing
Verified that the new tasks appear in the task runner.
Confirmed that tasks execute successfully for both Strapi and Medusa.