### PR TITLE
fix: migrate rust configs to moon 2.0

### DIFF
--- a/rust/tasks-project.yml
+++ b/rust/tasks-project.yml
@@ -14,7 +14,8 @@ fileGroups:
 tasks:
   cargo:
     command: 'cargo'
-    local: true
+    options:
+      persistent: true
 
   build: &build
     command: 'cargo build'
@@ -27,7 +28,8 @@ tasks:
   build-release:
     <<: *build
     command: 'cargo build --release'
-    local: true
+    options:
+      persistent: true
 
   check:
     command: 'cargo check --all-targets'
@@ -42,7 +44,8 @@ tasks:
     inputs:
       - '@group(cargo)'
       - '@group(sources)'
-    local: true
+    options:
+      persistent: true
     env: *env
 
   format: &format
@@ -57,7 +60,8 @@ tasks:
   format-write:
     <<: *format
     command: 'cargo fmt --all -- --emit=files'
-    local: true
+    options:
+      persistent: true
 
   lint:
     command: 'cargo clippy --all-targets'
@@ -71,7 +75,8 @@ tasks:
   lint-fix:
     extends: 'lint'
     args: '--fix --allow-dirty --allow-staged'
-    local: true
+    options:
+      persistent: true
 
   test:
     command: 'cargo nextest run'

--- a/rust/tasks-workspace.yml
+++ b/rust/tasks-workspace.yml
@@ -18,7 +18,8 @@ fileGroups:
 tasks:
   cargo:
     command: 'cargo'
-    local: true
+    options:
+      persistent: true
 
   build: &build
     command: 'cargo build'
@@ -31,7 +32,8 @@ tasks:
   build-release:
     <<: *build
     command: 'cargo build --release'
-    local: true
+    options:
+      persistent: true
 
   check:
     command: 'cargo check --workspace --all-targets'
@@ -46,7 +48,8 @@ tasks:
     inputs:
       - '@group(cargo)'
       - '@group(sources)'
-    local: true
+    options:
+      persistent: true
     env: *env
 
   format: &format
@@ -61,7 +64,8 @@ tasks:
   format-write:
     <<: *format
     command: 'cargo fmt --all -- --emit=files'
-    local: true
+    options:
+      persistent: true
 
   lint: &lint
     command: 'cargo clippy --workspace --all-targets'
@@ -75,7 +79,8 @@ tasks:
   lint-fix:
     <<: *lint
     command: 'cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged'
-    local: true
+    options:
+      persistent: true
 
   test:
     command: 'cargo nextest run --workspace'


### PR DESCRIPTION
I used these configs in a new rust project with moon 2.0.1, and noticed local has been removed.

```
Error: config::parse::failed

  × Failed to parse moon.yml.
  ╰─▶   × tasks.cargo.local: unknown field `local`, expected one of `extends`, `description`, `command`, `args`,
        │ `dependsOn`, `deps`, `env`, `inputs`, `outputs`, `options`, `preset`, `script`, `toolchain`, `toolchains`,
        │ `type`

  help: https://moonrepo.dev/docs/config/project
  ```

As per the [migration guide](https://moonrepo.dev/docs/migrate/2.0#configuration-moon-moontasks) and [docs](https://moonrepo.dev/docs/concepts/task#persistent), I made the necessary changes, which are just a couple of:

```diff
-    local: true
+    options:
+      persistent: true
```

If people extend these configs, however, we could break setups that use versions prior to 1.6.0.